### PR TITLE
Added functionality in GameManager to get the required number of attack attempts to upgrade defense

### DIFF
--- a/TheEthicalHackerCup/Assets/DefenseMenu/Scripts/AttackAttemptText.cs
+++ b/TheEthicalHackerCup/Assets/DefenseMenu/Scripts/AttackAttemptText.cs
@@ -7,8 +7,8 @@ public class AttackAttemptText : MonoBehaviour
 {
     private TextMeshProUGUI attemptText;
     private string attackAttemptText = "Attacks Attempted";
-    private int attemptsTotal;
-    private int attemptCompleted;
+    private int attemptsRequiredToUpgrade;
+    private int attemptsCompleted;
 
     [SerializeField] SecurityConcepts sc;
 
@@ -21,9 +21,9 @@ public class AttackAttemptText : MonoBehaviour
         setupColors();
         GameManager.GetInstance().InitializeGameState();
         attemptText = this.gameObject.GetComponent<TextMeshProUGUI>();
-        attemptCompleted = GameManager.GetInstance().GetAttackMinigamesAttempted(sc);
-        attemptsTotal = GameManager.GetInstance().GetDefenseUpgradeLevel(sc) + 1;
-        string attempts = attackAttemptText + "\n" + attemptCompleted + "/" + attemptsTotal;
+        attemptsCompleted = GameManager.GetInstance().GetAttackMinigamesAttempted(sc);
+        attemptsRequiredToUpgrade = GameManager.GetInstance().GetAttackMinigamesAttemptsRequiredToUpgrade(sc);
+        string attempts = attackAttemptText + "\n" + attemptsCompleted + "/" + attemptsRequiredToUpgrade;
         attemptText.text = attempts;
         attemptText.color = isAttemptComplete() ? green : red;
     }
@@ -46,6 +46,6 @@ public class AttackAttemptText : MonoBehaviour
     public bool isAttemptComplete()
     {
         // checks if completed attack attempts equal to total attack attempts
-        return attemptCompleted == attemptsTotal;
+        return attemptsCompleted >= attemptsRequiredToUpgrade;
     }
 }

--- a/TheEthicalHackerCup/Assets/EditModeTests/GameManagerTests.cs
+++ b/TheEthicalHackerCup/Assets/EditModeTests/GameManagerTests.cs
@@ -146,6 +146,7 @@ public class GameManagerTests
             for (int i = 1; i <= 5; i++)
             {
                 _currentExpectedInteger = i;
+                GameManager.GetInstance().AttemptAttackMinigame(concept); // Attack attempt required to upgrade
                 GameManager.GetInstance().UpgradeDefenseUpgradeLevel(concept);
             }
         }
@@ -175,6 +176,7 @@ public class GameManagerTests
             foreach (SecurityConcepts concept in Enum.GetValues(typeof(SecurityConcepts)))
             {
                 _currentExpectedSecurityConcept = concept;
+                GameManager.GetInstance().AttemptAttackMinigame(concept); // Attack attempt required to upgrade
                 GameManager.GetInstance().UpgradeDefenseUpgradeLevel(concept);
             }
         }
@@ -247,6 +249,39 @@ public class GameManagerTests
 
     }
 
+    [Test]
+    public void AttackMinigamesRequiredTest()
+    {
+        BeforeEach();
+        foreach (SecurityConcepts concept in Enum.GetValues(typeof(SecurityConcepts)))
+        {
+            // Everyone needs one attempt to upgrade initially
+            Assert.AreEqual(1, GameManager.GetInstance().GetAttackMinigamesAttemptsRequiredToUpgrade(concept));
+
+            // Attack minigame attempt everyone once
+            GameManager.GetInstance().AttemptAttackMinigame(concept);
+
+            // Before upgrading, everyone still needs one attempt to upgrade, even if they have an attempt
+            Assert.AreEqual(1, GameManager.GetInstance().GetAttackMinigamesAttemptsRequiredToUpgrade(concept));
+
+            // Then upgrade once successfully
+            Assert.AreEqual(true, GameManager.GetInstance().UpgradeDefenseUpgradeLevel(concept));
+
+            // Everyone now needs 2 attempts to get the next upgrade
+            Assert.AreEqual(2, GameManager.GetInstance().GetAttackMinigamesAttemptsRequiredToUpgrade(concept));
+
+            // Can't upgrade without another attack game attempt
+            Assert.AreEqual(false, GameManager.GetInstance().UpgradeDefenseUpgradeLevel(concept));
+            Assert.AreEqual(1, GameManager.GetInstance().GetDefenseUpgradeLevel(concept));
+
+            //Fully upgrade
+            do { GameManager.GetInstance().AttemptAttackMinigame(concept); }
+            while (GameManager.GetInstance().UpgradeDefenseUpgradeLevel(concept));
+
+            // Ensure max defense upgrade level matches requirements to upgrade once fully upgraded
+            Assert.AreEqual(GameManager.GetInstance().GetMaxDefenseUpgradeLevel(concept), GameManager.GetInstance().GetAttackMinigamesAttemptsRequiredToUpgrade(concept));
+        }
+    }
 
     [Test]
     public void AttackSpecificHeatTest()

--- a/TheEthicalHackerCup/Assets/EditModeTests/GameManagerTests.cs.meta
+++ b/TheEthicalHackerCup/Assets/EditModeTests/GameManagerTests.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 68cca6c0f614f4445b0633b447f577d4
+guid: 4af576e2522ebd043af6271cc6b61eaa
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/TheEthicalHackerCup/Assets/Scripts/GameManager.cs
+++ b/TheEthicalHackerCup/Assets/Scripts/GameManager.cs
@@ -102,9 +102,17 @@ public class GameManager
     {
         return _securityConceptProgressDictionary[concept].GetCurrentDefenseUpgradeLevel();
     }
+    public int GetMaxDefenseUpgradeLevel(SecurityConcepts concept)
+    {
+        return _securityConceptProgressDictionary[concept].GetMaxDefenseUpgradeLevel();
+    }
     public int GetAttackMinigamesAttempted(SecurityConcepts concept)
     {
         return _securityConceptProgressDictionary[concept].GetAttackMinigamesAttempted();
+    }
+    public int GetAttackMinigamesAttemptsRequiredToUpgrade(SecurityConcepts concept)
+    {
+        return _securityConceptProgressDictionary[concept].GetAttackMinigameAttemptsRequiredToUpgrade();
     }
     public int GetAttackSpecificHeat(SecurityConcepts concept)
     {
@@ -150,13 +158,15 @@ public class GameManager
 
 
     // Non primitive updates
-    public void UpgradeDefenseUpgradeLevel(SecurityConcepts concept)
+    public bool UpgradeDefenseUpgradeLevel(SecurityConcepts concept)
     {
         if (this._securityConceptProgressDictionary[concept].UpgradeDefense())
         {
             // Upgraded successfully returns true and invokes the action event
             OnDefenseUpgradeLevelsChange?.Invoke(concept, this._securityConceptProgressDictionary[concept].GetCurrentDefenseUpgradeLevel());
+            return true;
         }
+        return false;
     }
     public void AttemptAttackMinigame(SecurityConcepts concept)
     {

--- a/TheEthicalHackerCup/Assets/Scripts/SecurityConceptProgress.cs
+++ b/TheEthicalHackerCup/Assets/Scripts/SecurityConceptProgress.cs
@@ -1,3 +1,4 @@
+using System;
 // using System;
 
 public class SecurityConceptProgress
@@ -25,13 +26,15 @@ public class SecurityConceptProgress
     public int GetAttackMinigamesAttempted() { return this._attackMinigamesAttempted; }
     public int GetHeat() { return this._heat; }
 
+    public int GetAttackMinigameAttemptsRequiredToUpgrade() { return Math.Min(this._maxDefenseUpgradeLevel, this._currentDefenseUpgradeLevel + 1); }
+
     // Boolean Indicators
     public bool IsFullyUpgraded() { return this._currentDefenseUpgradeLevel >= this._maxDefenseUpgradeLevel; }
 
     // Boosters
     public bool UpgradeDefense()
     {
-        if (this._currentDefenseUpgradeLevel + 1 > this._maxDefenseUpgradeLevel)
+        if (this._currentDefenseUpgradeLevel + 1 > this._maxDefenseUpgradeLevel || this._attackMinigamesAttempted < this.GetAttackMinigameAttemptsRequiredToUpgrade())
         {
             return false;
         }

--- a/TheEthicalHackerCup/Assets/Scripts/SecurityConceptProgress.cs
+++ b/TheEthicalHackerCup/Assets/Scripts/SecurityConceptProgress.cs
@@ -34,7 +34,7 @@ public class SecurityConceptProgress
     // Boosters
     public bool UpgradeDefense()
     {
-        if (this._currentDefenseUpgradeLevel + 1 > this._maxDefenseUpgradeLevel || this._attackMinigamesAttempted < this.GetAttackMinigameAttemptsRequiredToUpgrade())
+        if (this._currentDefenseUpgradeLevel >= this._maxDefenseUpgradeLevel || this._attackMinigamesAttempted < this.GetAttackMinigameAttemptsRequiredToUpgrade())
         {
             return false;
         }


### PR DESCRIPTION
The required attack attempts to upgrade the defense will be the ```min(maxUpgradeLevel, currentUpgradeLevel+1)```
Also added a method to get the max defense upgrade level for each security concept
Updated tests

Incorporated the attack attempts required to upgrade number calculation into the defense menu area