### PR TITLE
Updated GameManager to handle scene switching and tutorial files. Integration with QuizUI

### DIFF
--- a/TheEthicalHackerCup/Assets/AttackMinigames/Firewall_Attack/Scripts/ContinueButtonHandler.cs
+++ b/TheEthicalHackerCup/Assets/AttackMinigames/Firewall_Attack/Scripts/ContinueButtonHandler.cs
@@ -1,15 +1,13 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.SceneManagement;
-using UnityEngine.UI;
 
 public class ContinueButtonHandler : MonoBehaviour
 {
     public GameObject CanvasUI;
-    
+
     public void HandleContinueButtonClick()
     {
+        //SAMPLE CALL BELOW USED TO TEST TUTORIAL GOING TO LEARNINGSCENE AND THEN RETURNING TO ORIGINAL SCENE
+        // GameManager.GetInstance().StartLearningMinigameTutorial("Firewall4"); 
         if (FirewallAttackGameManager.GetInstance().CurrentGameState == FirewallAttackStates.Intro)
         {
             CanvasUI.SetActive(false); // Hiding Canvas UI layers
@@ -18,7 +16,7 @@ public class ContinueButtonHandler : MonoBehaviour
         else
         {
             FirewallAttackGameManager.GetInstance().InitializeGameState();
-            GameManager.GetInstance().AfterActionReportText = "Firewall attack completed dude";
+            GameManager.GetInstance().SwitchToAfterActionReportScene("Firewall attack completed dude");
         }
     }
 }

--- a/TheEthicalHackerCup/Assets/DefenseMenu/Scripts/DefenseUpgradeClick.cs
+++ b/TheEthicalHackerCup/Assets/DefenseMenu/Scripts/DefenseUpgradeClick.cs
@@ -28,12 +28,10 @@ public class DefenseUpgradeClick : MonoBehaviour
     {
         if (upgradeButton.interactable)
         {
-            GameManager.GetInstance().SetNextLearningMinigameSecurityConcept(sc);
             progressBar.GetComponent<ProgressBar>().updateProgressBar(); //This might not need to be dynamically boosted. Instead, set it when the scene loads
 
             // Launch learning minigame 
-            SceneManager.LoadScene("LearningScene");
-
+            GameManager.GetInstance().StartLearningMinigameUpgradeQuiz(sc);
         }
     }
 

--- a/TheEthicalHackerCup/Assets/EditModeTests/GameManagerTests.cs
+++ b/TheEthicalHackerCup/Assets/EditModeTests/GameManagerTests.cs
@@ -61,16 +61,7 @@ public class GameManagerTests
         GameManager.GetInstance().UpgradeDefenseUpgradeLevel(SecurityConcepts.Firewall);
         Assert.AreEqual("Firewall2", GameManager.GetInstance().GetNextLearningMinigameFilename());
     }
-    [Test]
-    public void NextLearningMinigameSecurityConceptTest()
-    {
-        BeforeEach();
-        // Firewall is the default
-        Assert.AreEqual(SecurityConcepts.Firewall, GameManager.GetInstance().GeNextLearningMinigameSecurityConcept());
-        SecurityConcepts secConcept = SecurityConcepts.DDoS;
-        GameManager.GetInstance().SetNextLearningMinigameSecurityConcept(secConcept);
-        Assert.AreEqual(secConcept, GameManager.GetInstance().GeNextLearningMinigameSecurityConcept());
-    }
+
 
 
     [Test]

--- a/TheEthicalHackerCup/Assets/Resources/Firewall4.xml
+++ b/TheEthicalHackerCup/Assets/Resources/Firewall4.xml
@@ -1,6 +1,6 @@
 <Quiz>
-	<Slide Name="SLIDE 1">
-		<Content Type="Learning.InfoContent">Welcome</Content>
+	<Slide Name="Firewall 4">
+		<Content Type="Learning.InfoContent">This is Firewall4.xml</Content>
 	</Slide>
 	<Slide Name="SLIDE 2">
 		<Content Type="Learning.CheckBox">

--- a/TheEthicalHackerCup/Assets/Scripts/Learning/QuizUIManager.cs
+++ b/TheEthicalHackerCup/Assets/Scripts/Learning/QuizUIManager.cs
@@ -1,8 +1,6 @@
 using UnityEngine;
 using UnityEngine.UI;
 using TMPro;
-using UnityEngine.SceneManagement;
-using static Codice.CM.WorkspaceServer.WorkspaceTreeDataStore;
 
 namespace Learning
 {
@@ -66,13 +64,7 @@ namespace Learning
         private void handleClosed(object sender, QuizClosedEvent evt)
         {
             Debug.Log(evt.pass ? "Quiz Passed" : "Quiz Failed");
-            if (evt.pass)
-            {
-                GameManager.GetInstance().UpgradeDefenseUpgradeLevel(
-                    GameManager.GetInstance().GeNextLearningMinigameSecurityConcept()
-                );
-            }
-            SceneManager.LoadScene("MainScene");
+            GameManager.GetInstance().EndLearningMinigame(evt.pass); //TODO: WHEN IN TUTORIAL MODE, THIS PARAM MUST BE FALSE.
         }
 
         private void handleNextSlide(object sender, NextSlideEvent evt)


### PR DESCRIPTION
Scene switching operations in/out of LearningMini all now happens in GameManager
Added functionality for tutorials that returns the player to the source scene after the tutorial is complete

Switching to a tutorial is as easy as `GameManager.GetInstance().StartLearningMinigameTutorial("TutorialXmlFileNoExtensionString")`, which will bring the player back to the source scene after the tutorial is complete